### PR TITLE
Extended charset encoding detection options

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,7 +3,7 @@
 var opts = require('minimist')(process.argv.slice(2))
 
 if(opts.h || opts.help) {
-  console.error('usage: to-utf-8 [--enc <soruce encoding>] [--conf <minimum confidence>]')
+  console.error('usage: to-utf-8 [--enc <source encoding>] [--conf <minimum confidence>]')
   process.exit()
 }
 

--- a/index.js
+++ b/index.js
@@ -18,18 +18,20 @@ function getSupportedEncoding (encoding) {
 
 function toutf8 (opts) {
   if(!opts) opts = {}
-  if(typeof encoding == 'string') opts = { encoding: opts }
+  if(typeof opts === 'string') opts = { encoding: opts }
   var conf = opts.confidence || 0
+  var newline = opts.newline !== false
+  var detectSize = opts.detectSize || 65535
   var encoding = opts.encoding
   // encoding given
   if(encoding) return convertFrom(encoding)
-    
+
   // detect encoding first
-  return peek(function (data, swap) {
+  return peek({newline: newline, maxBuffer: detectSize}, function (data, swap) {
     if(!Buffer.isBuffer(data)) return swap(new Error('No buffer'))
     var matches = detect(data)
     var encoding = matches.length > 0 && matches[0].confidence > conf
-      ? matches[0].charsetName 
+      ? matches[0].charsetName
       : 'utf8'
     encoding = getSupportedEncoding(encoding)
     swap(null, convertFrom(encoding))

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,8 @@ fs.createReadStream('utf16-le-file.txt')
 You can also pass an options object instead with the following keys:
 * `confidence` Minimum confidence for the detected source encoding. If not reached assume `utf-8`
 * `encoding` Same as passing a string directly. Use the given encoding instead of detecting it.
+* `newline` Use input text until newline is reached to detect encoding (default `true`)
+* `detectSize` Maximum size from input to detect encoding (default `65535`)
 
 ## CLI
 


### PR DESCRIPTION
@finnp when i was trying to use your module to convert a file from srt to vtt I found your default limits to detect encoding (only use first line) was not enough because srt's first line is always `1` so the detection part was useless.

I added two options to improve encoding detection
- `newline` Use input text until newline is reached to detect encoding (default `true`)
- `detectSize` Maximum size from input to detect encoding (default `65535`)
  
  as you can see the given defaults behaves exactly as your current implementation, making the changes  backward compatible.
